### PR TITLE
fix incorrect PHP5 references that weren't updated

### DIFF
--- a/rootfs/etc/nginx/modules.d/99-icingaweb.conf
+++ b/rootfs/etc/nginx/modules.d/99-icingaweb.conf
@@ -13,7 +13,7 @@
       fastcgi_index index.php;
       fastcgi_param ICINGAWEB_CONFIGDIR /etc/icingaweb2;
       fastcgi_param SCRIPT_FILENAME /usr/share/webapps/icingaweb2/public/index.php;
-      fastcgi_pass unix:/run/php5-fpm-worker-01.sock;
+      fastcgi_pass unix:/run/php7-fpm-worker-01.sock;
       include fastcgi_params;
     }
 

--- a/rootfs/etc/php/php-fpm.conf
+++ b/rootfs/etc/php/php-fpm.conf
@@ -1,6 +1,6 @@
 
 [global]
-pid                         = /run/php5-fpm.pid
+pid                         = /run/php7-fpm.pid
 daemonize                   = no
 error_log                   = /proc/self/fd/1
 log_level                   = error
@@ -18,7 +18,7 @@ prefix                              = /var/log/php-fpm
 user                                = nginx
 group                               = nginx
 
-listen                              = /run/php5-fpm-$pool.sock
+listen                              = /run/php7-fpm-$pool.sock
 listen.owner                        = nginx
 listen.group                        = nginx
 


### PR DESCRIPTION
Hello,
i found some php5 references that might be missed when upgrade to php7 was done