### PR TITLE
Fix nginx syntax to disable error logs

### DIFF
--- a/compose/config/nginx.conf
+++ b/compose/config/nginx.conf
@@ -39,8 +39,8 @@ http {
     server_name         _;
 
     log_not_found       off;
-    access_log          off;
-    error_log           off;
+    access_log          /dev/null;
+    error_log           /dev/null;
 
     # we want an permantent redirect to https
     #
@@ -77,7 +77,7 @@ http {
     location /icinga {
       log_not_found       off;
       access_log          /dev/stdout;
-      error_log           off;
+      error_log           /dev/null;
 
       add_header X-Backend "icingaweb2";
 
@@ -107,8 +107,8 @@ http {
     location /grafana/ {
 
       log_not_found       off;
-      access_log          off;
-      error_log           off;
+      access_log          /dev/null;
+      error_log           /dev/null;
 
       add_header X-Backend "grafana";
 


### PR DESCRIPTION
Setting `error_log off` will create a file named `off` in the directory where nginx is running.

See:
https://www.wpoven.com/tutorial/how-to-disable-nginx-logs-on-your-server/
http://nginx.org/en/docs/ngx_core_module.html#error_log